### PR TITLE
リモートユーザーの2種のユニーク制約同士のミスマッチの自動修正を試みるように

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -23,10 +23,11 @@ import { isDuplicateKeyValueError } from '../../../misc/is-duplicate-key-value-e
 import { toPuny } from '../../../misc/convert-host';
 import { UserProfile } from '../../../models/entities/user-profile';
 import { validActor } from '../../../remote/activitypub/type';
-import { getConnection } from 'typeorm';
+import { getConnection, Not } from 'typeorm';
 import { toArray } from '../../../prelude/array';
 import { fetchInstanceMetadata } from '../../../services/fetch-instance-metadata';
 import { normalizeForSearch } from '../../../misc/normalize-for-search';
+import { resolveUser } from '../../resolve-user';
 
 const logger = apLogger;
 
@@ -186,16 +187,22 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 	} catch (e) {
 		// duplicate key error
 		if (isDuplicateKeyValueError(e)) {
-			// /users/@a => /users/:id のように入力がaliasなときにエラーになることがあるのを対応
+			// 同じ@username@hostを持つものがあった場合、エラーで被った先を返す
 			const u = await Users.findOne({
-				uri: person.id
+				uri: Not(person.id as string),
+				usernameLower: person.preferredUsername!.toLowerCase(),
+				host,
 			});
 
 			if (u) {
-				user = u as IRemoteUser;
-			} else {
-				throw new Error('already registered');
+				throw {
+					code: 'DUPLICATED_USERNAME',
+					with: u,
+				};
 			}
+
+			logger.error(e);
+			throw e;
 		} else {
 			logger.error(e);
 			throw e;
@@ -402,7 +409,21 @@ export async function resolvePerson(uri: string, resolver?: Resolver): Promise<U
 
 	// リモートサーバーからフェッチしてきて登録
 	if (resolver == null) resolver = new Resolver();
-	return await createPerson(uri, resolver);
+
+	try {
+		return await createPerson(uri, resolver);
+	} catch (e) {
+		if (e.code === 'DUPLICATED_USERNAME') {
+			// uriからresolveしたユーザーを作成しようとしたら同じ @username@host が既に存在した場合にここに来る
+			const existUser = e.with as IRemoteUser;
+			logger.warn(`Duplicated username. input(uri=${uri}) exist(uri=${existUser.uri} username=${existUser.username}, host=${existUser.host})`);
+
+			// WebFinger(@username@host)からresync をトリガする (24時間以上古い場合)
+			resolveUser(existUser.username, existUser.host);
+		}
+
+		throw e;
+	}
 }
 
 const services: {


### PR DESCRIPTION
## Summary
いちおう misskey-m544 からのport

リモートユーザーは2種のユニーク制約を持っているけど
- uri (eg: https://example.com/users/id1)
- usernameLower & host (eg: user1 & example.com)

リモート実装がMisskeyとかの場合id1のところは自動生成なので
リモートでDBを初期化させるなどが行なわれた場合に
- uri (eg: https://example.com/users/id2) ★
- usernameLower & host (eg: user1 & example.com)

みたいなのが登場してしまう。

これを、新規のuriとみなしてuriをキーとして登録しようとすると、もう一方のユニーク制約にかかってしまう。

これを解決させるために、それを検出したら usernameLower & host での WebFinger からやり直して不整合を修正するようにする。
(ただし24時間くらいラグがある)

なお、これがなくても`@user1@example.com`形式で参照された場合24時間に1回くらい自動で補正される。