### PR TITLE
Increase maximum bio length to 5000

### DIFF
--- a/migration/1627928402467-bio-length-5000.ts
+++ b/migration/1627928402467-bio-length-5000.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class bioLength50001627928402467 implements MigrationInterface {
+    name = 'bioLength50001627928402467'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`ALTER TABLE "user_profile" ALTER COLUMN "description" TYPE character varying(5120)`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`ALTER TABLE "user_profile" ALTER COLUMN "description" TYPE character varying(2048)`, undefined);
+    }
+
+}

--- a/src/models/entities/user-profile.ts
+++ b/src/models/entities/user-profile.ts
@@ -30,7 +30,7 @@ export class UserProfile {
 	public birthday: string | null;
 
 	@Column('varchar', {
-		length: 2048, nullable: true,
+		length: 5120, nullable: true,
 		comment: 'The description (bio) of the User.'
 	})
 	public description: string | null;

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -57,7 +57,7 @@ function validateActor(x: IObject, uri: string): IActor {
 	validate('inbox', x.inbox, $.str.min(1));
 	validate('preferredUsername', x.preferredUsername, $.str.min(1).max(128).match(/^\w([\w-.]*\w)?$/));
 	validate('name', x.name, $.optional.nullable.str.max(128));
-	validate('summary', x.summary, $.optional.nullable.str.max(2048));
+	validate('summary', x.summary, $.optional.nullable.str.max(5000));
 
 	const idHost = toPuny(new URL(x.id!).hostname);
 	if (idHost !== expectHost) {

--- a/test/activitypub.ts
+++ b/test/activitypub.ts
@@ -70,4 +70,34 @@ describe('ActivityPub', () => {
 			assert.deepStrictEqual(note?.text, post.content);
 		});
 	});
+
+	describe('Parse bio 5000', () => {
+		const host = 'https://host1.test';
+		const preferredUsername = `${rndstr('A-Z', 4)}${rndstr('a-z', 4)}`;
+		const actorId = `${host}/users/${preferredUsername.toLowerCase()}`;
+
+		const actor = {
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: actorId,
+			type: 'Person',
+			preferredUsername,
+			inbox: `${actorId}/inbox`,
+			outbox: `${actorId}/outbox`,
+			summary: rndstr('0-9A-Za-z', 5000)
+		};
+
+		it('Parse', async () => {
+			const { MockResolver } = await import('./misc/mock-resolver');
+			const { createPerson } = await import('../src/remote/activitypub/models/person');
+
+			const resolver = new MockResolver();
+			resolver._register(actor.id, actor);
+
+			const user = await createPerson(actor.id, resolver);
+
+			assert.deepStrictEqual(user.uri, actor.id);
+			assert.deepStrictEqual(user.username, actor.preferredUsername);
+			assert.deepStrictEqual(user.inbox, actor.inbox);
+		});
+	});
 });


### PR DESCRIPTION
## Summary
Reverted
New pull request is ~~#1995~~ #1996

Increase maximum remote bio length to 5000

バリデーションでサロゲートペアを2文字としてカウントしているなどのため、5000でも弾かれる可能性はある。
DBカラムはtextにした方がいいかもしれないけど、しちゃうと戻せないので5120にしてる。